### PR TITLE
Match comments first so no color syntax is applied if another pattern matches

### DIFF
--- a/grammars/terraform.cson
+++ b/grammars/terraform.cson
@@ -7,6 +7,12 @@
 
 'patterns': [
 	{
+		'match': '(#.*)'
+		'captures':
+			'1':
+				'name': 'comment'
+	}
+	{
 		'match': '^(.+)\\s*=\\s*(["\'].+["\'])'
 		'captures':
 			'1':
@@ -56,12 +62,6 @@
 						'name': 'string'
 			}
 		]
-	}
-	{
-		'match': '(#.*)'
-		'captures':
-			'1':
-				'name': 'comment'
 	}
 	{
 		'begin': '.*/\\*'


### PR DESCRIPTION
Before : 

![Before the fix](https://cloud.githubusercontent.com/assets/437946/4899871/755fbb6e-6420-11e4-8f80-f55e0ea98430.png)

After : 

![After the fix](https://cloud.githubusercontent.com/assets/437946/4899877/818b9796-6420-11e4-835a-f3eb171e996b.png)
