### PR TITLE
enhanced string interpolations

### DIFF
--- a/example.tf
+++ b/example.tf
@@ -1,0 +1,51 @@
+# taken from https://github.com/hashicorp/terraform/blob/master/examples/aws-s3-cross-account-access/main.tf
+
+provider "aws" {
+	alias = "prod"
+
+	region = "us-east-1"
+	access_key = "${var.prod_access_key}"
+	secret_key = "${var.prod_secret_key}"
+	number = 12kb
+	example = true
+	list = [true, false, 123, "$${var.foo.*} = ${var.foo.*}"]
+}
+
+resource "aws_s3_bucket" "prod" {
+	provider = "aws.prod"
+
+	bucket = "${concat(var.bucket_name, 4 - 3)}"
+	acl = "private"
+	policy = <<POLICY_YML
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowTest",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${var.test_account_id}:root"
+            },
+            "Action": "s3:*",
+            "Resource": "arn:aws:s3:::${var.bucket_name}/*"
+        }
+    ]
+}
+POLICY_YML
+}
+
+resource "aws_s3_bucket_object" "prod" {
+	provider = "aws.prod"
+
+	bucket = "${aws_s3_bucket.prod.id}"
+	key = "object-uploaded-via-prod-creds"
+	source = "${path.module}/prod.txt"
+}
+
+provider "aws" {
+	alias = "test"
+
+	region = "us-east-1"
+	access_key = "${var.*.test_access_key}"
+	secret_key = "${var.test_secret_key}"
+}

--- a/grammars/interpolated.cson
+++ b/grammars/interpolated.cson
@@ -1,0 +1,49 @@
+'scopeName': 'text.interpolation.hashicorp'
+'name': 'HashiCorp String Interpolation'
+'injectionSelector': 'string.interpolated'
+'patterns': [
+  {
+    'name': 'string'
+    'match': '\\$\\$'
+  }
+  {
+    'begin': '(\\$\\{)'
+    'beginCaptures':
+      '1':
+        'name': 'variable.interpolation.begin'
+    'end': '(\\})'
+    'endCaptures':
+      '1':
+        'name': 'variable.interpolation.end'
+    'name': 'none'
+    'patterns': [
+      {
+        'include': '#interplang'
+      }
+    ]
+  }
+]
+'repository':
+  'interplang':
+    'patterns': [
+      {
+        'match': '\\b(concat|element|file|format|formatlist|join|length|lookup|replace|split)\\s*(?:\\()'
+        'captures':
+          '1':
+            'name': 'support.function'
+          '2':
+            'name': 'meta.brace.round'
+      }
+      {
+        'match': '\\b(var|self|module|count|path)\\b'
+        'name': 'support.variable'
+      }
+      {
+        'match': '\\b\\d+\\b'
+        'name': 'constant.numeric'
+      }
+      {
+        'match': '\\*'
+        'name': 'support.constant'
+      }
+    ]

--- a/grammars/terraform.cson
+++ b/grammars/terraform.cson
@@ -4,80 +4,177 @@
 	'tf'
 	'tfvars'
 ]
+'foldingStartMarker': '\\{\\s*$'
+'foldingStopMarker': '^\\s*\\}'
 
 'patterns': [
-	{
-		'match': '#.*'
-		'name': 'comment'
-	}
-	{
-		'match': '^(.+)\\s*=\\s*(["\'].+["\'])'
-		'captures':
-			'1':
-				'name': 'keyword'
-			'2':
-				'name': 'string'
-	}
-	{
-		'match': '^(\\w+)\\s+(["\'].+["\'])\\s*\\{\\s*\\}'
-		'captures':
-			'1':
-				'name': 'keyword'
-			'2':
-				'name': 'string'
-	}
-	{
-		'begin': '^(\\w+)\\s+(["\'].+["\'])'
-		'end': '^}'
-		'captures':
-			'1':
-				'name': 'keyword'
-			'2':
-				'name': 'string'
-		'patterns': [
-			{
-				'match': '#.*'
-				'name': 'comment'
-			}
-			{
-				'match': '(\\w+)\\s*(["\'].+["\'])?\\s*[\\{\\[\\=]'
-				'captures':
-					'1':
-						'name': 'constant.language'
-					'2':
-						'name': 'string'
-			}
-			{
-			    'match': '(["\']\\$\\{)(.+)(\\}.*["\'])'
-			    'captures':
-			        '1':
-			            'name': 'string'
-			        '2':
-			            'name': 'keyword'
-			        '3':
-			            'name': 'string'
-			}
-			{
-				'match': '(["\'].+["\'])'
-				'captures':
-					'1':
-						'name': 'string'
-			}
-		]
-	}
-	{
-		'begin': '.*/\\*'
-		'end': '.*\\*/'
-		'captures':
-			'0':
-				'name': 'comment'
-		'patterns': [
-			{
-				'match': '.+'
-				'captures':
-					'0':
-						'name': 'comment'
-			}
-		]
-	}
+	{'include': '#comments'}
+	{'include': '#sections'}
+	{'include': '#literals'}
+	{'include': '#keywords'}
+	{'include': '#properties'}
 ]
+
+'repository':
+	'comments':
+		'patterns': [
+				{
+					'match': '#.*'
+					'name': 'comment.number-sign'
+				}
+				{
+					'begin': '\\/\\*'
+					'end': '\\*\\/'
+					'name': 'comment.block'
+				}
+		]
+	'primitives':
+		'patterns': [
+			{
+				'match': '\\b(?:true|false)\\b'
+				'name': 'constant.language'
+			}
+			{
+				'match': '\\b(?:\\d+[kKmMgG]?b?)\\b'
+				'name': 'constant.numeric'
+			}
+			{'include': '#heredocs'}
+			{'include': '#strings'}
+		]
+	'strings':
+		'patterns': [
+			{
+				'comment': 'Terraform claims it only uses double-quoted strings'
+				'begin': '"'
+				'end': '"'
+				'name': 'string.interpolated'
+				'contentName': 'entity'
+			}
+		]
+	'heredocs':
+		'patterns': [
+			{
+				'begin': '<<(\\w*JSON)$'
+				'beginCaptures':
+					'1':
+						'name': 'keyword.control.heredoc-token'
+				'end': '^(\\1)$'
+				'endCaptures':
+					'1':
+						'name': 'keyword.control.heredoc-token'
+				'contentName': 'string.interpolated'
+				'patterns': [
+					{'include': 'source.json'}
+				]
+			}
+			{
+				'begin': '<<(\\w*YA?ML)$'
+				'beginCaptures':
+					'1':
+						'name': 'keyword.control.heredoc-token'
+				'end': '^(\\1)$'
+				'endCaptures':
+					'1':
+						'name': 'keyword.control.heredoc-token'
+				'contentName': 'string.interpolated'
+				'patterns': [
+					{'include': 'source.yaml'}
+				]
+			}
+			{
+				'begin': '<<(\\w*XML)$'
+				'beginCaptures':
+					'1':
+						'name': 'keyword.control.heredoc-token'
+				'end': '^(\\1)$'
+				'endCaptures':
+					'1':
+						'name': 'keyword.control.heredoc-token'
+				'contentName': 'string.interpolated'
+				'patterns': [
+					{'include': 'source.xml'}
+				]
+			}
+			{
+				'begin': '<<(\\w*SH)$'
+				'beginCaptures':
+					'1':
+						'name': 'keyword.control.heredoc-token'
+				'end': '^(\\1)$'
+				'endCaptures':
+					'1':
+						'name': 'keyword.control.heredoc-token'
+				'contentName': 'string.interpolated'
+				'patterns': [
+					{'include': 'source.shell'}
+				]
+			}
+			{
+				'begin': '<<(\\w+)$'
+				'beginCaptures':
+					'1':
+						'name': 'keyword.control.heredoc-token'
+				'end': '^(\\1)$'
+				'endCaptures':
+					'1':
+						'name': 'keyword.control.heredoc-token'
+				'name': 'keyword.operator.heredoc'
+				'contentName': 'string.interpolated'
+			}
+		]
+	'literals':
+		'patterns': [
+			{'include': '#primitives'}
+			{'include': '#lists'}
+		]
+	'lists':
+		'patterns': [
+			{
+				'name': 'language.list'
+				'begin': '\\['
+				'end': '\\]'
+				'patterns': [
+					{'include': '#primitives'}
+					{'match': ','}
+				]
+			}
+		]
+	'sections':
+		'patterns': [
+			{
+				'begin': '(\\w+)\\s*((:?"\\w*")*)\\s*(\\{)'
+				'beginCaptures':
+					'1':
+						'name': 'entity.name.section'
+					'2':
+						'name': 'variable.parameter'
+					'3':
+						'name': 'punctuation.section.begin'
+				'end': '(\\})'
+				'endCaptures':
+					'1':
+						'name': 'punctuation.section.end'
+				'name': 'meta.section'
+				'patterns': [
+					{'include': '$base'}
+				]
+			}
+		]
+	'properties':
+		'patterns': [
+			{
+				'match': '\\b(count|depends_on|lifecycle|create_before_destroy|prevent_destroy)\\b\\s*(=)'
+				'captures':
+					'1':
+						'name': 'support.variable'
+					'2':
+						'name': 'punctuation.assignment'
+			}
+		]
+	'keywords':
+		'patterns': [
+			{
+				'match': '\\b(resource|provider|variable|output|module)\\b'
+				'name': 'support.type'
+			}
+		]


### PR DESCRIPTION
Sorry for the giant code drop... unfortunately it's almost a complete re-write.

I started by just trying to fix multi-line comments but ended up adding a whole bunch more:
- booleans
- number literals, including supported suffixes
- syntax highlighting _inside_ string interpolations
  - functions
  - variables
  - literals
- support for heredoc strings
  - embedded syntax hightlighting based on token suffix (`<<CONFIG_JSON`, `<<CONFIG_YAML`, ...)
  - string interpolation highlighting inside the embedded language (this one is kind of magical)

<img width="562" alt="screenshot 2015-08-27 23 04 24" src="https://cloud.githubusercontent.com/assets/17978/9540283/caa238ec-4d11-11e5-90cf-fc06cbd4bd5a.png">
