### PR TITLE
Add autoindent rules

### DIFF
--- a/settings/language-terraform.cson
+++ b/settings/language-terraform.cson
@@ -1,0 +1,4 @@
+'.source.terraform':
+  'editor':
+    'increaseIndentPattern': '^.*(\\{[^}]*|\\[[^\\]]*)$'
+    'decreaseIndentPattern': '^\\s*[}\\]],?\\s*$'


### PR DESCRIPTION
Add autoindent rules for maps `{}` and lists `[]` referring to [language-json](https://github.com/atom/language-json/blob/master/settings/language-json.cson#L4-L5).
Fix #14.