### PR TITLE
Allow dashes in resource names + 	handle curly braces in regex

### DIFF
--- a/grammars/interpolated.cson
+++ b/grammars/interpolated.cson
@@ -43,6 +43,15 @@
         'name': 'constant.numeric'
       }
       {
+        'comment': 'Handle curly braces in regex eg. {1,2}'
+        'match': '(?:\\{)(\\d?)(?:,?)(\\d?)(?:\\})'
+        'captures':
+          '1':
+            'name': 'constant.numeric'
+          '2':
+            'name': 'constant.numeric'
+      }
+      {
         'begin': '(\\$\\{)'
         'beginCaptures':
           '1':

--- a/grammars/terraform.cson
+++ b/grammars/terraform.cson
@@ -146,7 +146,7 @@
 	'sections':
 		'patterns': [
 			{
-				'begin': '(\\w+)\\s*((:?"\\w*"\\s*)*)\\s*(\\{)'
+				'begin': '(\\w+)\\s*((:?"(\\w|-)*"\\s*)*)\\s*(\\{)'
 				'beginCaptures':
 					'1':
 						'name': 'entity.name.section'


### PR DESCRIPTION
Closes #15. I used the snippet in issue 15 as a test.