### PR TITLE
Fix `editor:toggle-line-comments` keyboard shorcut

### DIFF
--- a/settings/language-terraform.cson
+++ b/settings/language-terraform.cson
@@ -1,4 +1,5 @@
 '.source.terraform':
   'editor':
+    'commentStart': '# '
     'increaseIndentPattern': '^.*(\\{[^}]*|\\[[^\\]]*)$'
     'decreaseIndentPattern': '^\\s*[}\\]],?\\s*$'


### PR DESCRIPTION
This change ensures hitting `CMD-/` adds a `# ` to the front of the highlighted line. This ensures this grammer behaves in a similar way to Atom's other grammers.

Fixes #24

Signed-off-by: Seth Chisamore <schisamo@chef.io>