### PR TITLE
Recognize local variables in expressions

### DIFF
--- a/grammars/interpolated.cson
+++ b/grammars/interpolated.cson
@@ -35,7 +35,7 @@
             'name': 'meta.brace.round'
       }
       {
-        'match': '\\b(var|self|module|count|path)\\b'
+        'match': '\\b(var|local|self|module|count|path)\\b'
         'name': 'support.variable'
       }
       {


### PR DESCRIPTION
This is a more recent [Terraform feature](https://www.terraform.io/docs/configuration/locals.html) currently not highlighted by this grammer but I would like to see `${local.foo}` handled the same like `${var.foo}`.