### PR TITLE
Add fold end pattern

### DIFF
--- a/settings/language-terraform.cson
+++ b/settings/language-terraform.cson
@@ -3,4 +3,4 @@
     commentStart: '# '
     increaseIndentPattern: '^.*(\\{[^}]*|\\[[^\\]]*)$'
     decreaseIndentPattern: '^\\s*[}\\]],?\\s*$'
-    foldEndPattern: '^\\s*\\}'
+    foldEndPattern: '^\\s*[}\\]]$'

--- a/settings/language-terraform.cson
+++ b/settings/language-terraform.cson
@@ -1,5 +1,6 @@
 '.source.terraform':
-  'editor':
-    'commentStart': '# '
-    'increaseIndentPattern': '^.*(\\{[^}]*|\\[[^\\]]*)$'
-    'decreaseIndentPattern': '^\\s*[}\\]],?\\s*$'
+  editor:
+    commentStart: '# '
+    increaseIndentPattern: '^.*(\\{[^}]*|\\[[^\\]]*)$'
+    decreaseIndentPattern: '^\\s*[}\\]],?\\s*$'
+    foldEndPattern: '^\\s*\\}'


### PR DESCRIPTION
Add a foldEndPattern to the config settings (as well as removing redundant quotes).

This is a small usability fix as it makes entire blocks fold onto one line, which in turn lets things that use Atom folds like `vim-mode-plus` work well

e.g.

<kbd>yaz</kbd> - Copy the block the cursor is in (including braces) 